### PR TITLE
Google Bidding - Expose configurable field(s)

### DIFF
--- a/GoogleBiddingAdapter/src/main/java/com/chartboost/helium/googlebiddingadapter/GoogleBiddingAdapter.kt
+++ b/GoogleBiddingAdapter/src/main/java/com/chartboost/helium/googlebiddingadapter/GoogleBiddingAdapter.kt
@@ -34,7 +34,7 @@ class GoogleBiddingAdapter : PartnerAdapter {
     companion object {
         /**
          * List containing device IDs to be set for enabling Google Bidding test ads. It can be populated at
-         * any time and it will take effect for the next ad request. Remember to empty this list or
+         * any time and will take effect for the next ad request. Remember to empty this list or
          * stop setting it before releasing your app.
          */
         public var testDeviceIds = listOf<String>()


### PR DESCRIPTION
Google always clears out the test IDs list so as long as we call their API (with an empty or non-empty list) we should be fine here.