### PR TITLE
HB-4958: Google Bidding: QueryInfo 3-minute TTL

### DIFF
--- a/GoogleBiddingAdapter/src/main/java/com/chartboost/helium/googlebiddingadapter/GoogleBiddingAdapter.kt
+++ b/GoogleBiddingAdapter/src/main/java/com/chartboost/helium/googlebiddingadapter/GoogleBiddingAdapter.kt
@@ -53,7 +53,8 @@ class GoogleBiddingAdapter : PartnerAdapter {
             }
 
         /**
-         * The TTL for cached QueryInfo objects from Google.
+         * The TTL for cached QueryInfo objects. Ad requests with QueryInfo's older than this value
+         * will be discarded. Recommended by Google.
          */
         private const val QUERY_INFO_TTL_MINUTES = 3L
     }


### PR DESCRIPTION
I'll remove the value set in the `AppConfig`. It's fine having this hard-coded in the adapter—it's not going to change often (if at all).