### PR TITLE
Revert "[HB-6577] Google Mobile Ads SDK 22.4.0 (#50)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,6 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
-### 4.22.4.0.0
-- This version of the adapter has been certified with Google Mobile Ads SDK 22.4.0.
-
 ### 4.22.3.0.3
 - Add support for adaptive banner sizes.
 

--- a/GoogleBiddingAdapter/build.gradle.kts
+++ b/GoogleBiddingAdapter/build.gradle.kts
@@ -34,7 +34,7 @@ android {
         minSdk = 21
         targetSdk = 33
         // If you touch the following line, don't forget to update scripts/get_rc_version.zsh
-        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.22.4.0.0"
+        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.22.3.0.3"
         buildConfigField("String", "CHARTBOOST_MEDIATION_GOOGLE_BIDDING_ADAPTER_VERSION", "\"${android.defaultConfig.versionName}\"")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
@@ -69,7 +69,7 @@ dependencies {
     "remoteImplementation"("com.chartboost:chartboost-mediation-sdk:4.0.0")
 
     // Partner SDK
-    implementation("com.google.android.gms:play-services-ads:22.4.0")
+    implementation("com.google.android.gms:play-services-ads:22.3.0")
 
     // Adapter Dependencies
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4")

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Chartboost Mediation Google bidding adapter mediates Google bidding via the 
 
 In your `build.gradle`, add the following entry:
 ```
-    implementation "com.chartboost:chartboost-mediation-adapter-google-bidding:4.22.4.0.0"
+    implementation "com.chartboost:chartboost-mediation-adapter-google-bidding:4.22.3.0.3"
 ```
 
 ## Contributions


### PR DESCRIPTION
Due to the following issue described here:
https://github.com/googleads/googleads-mobile-unity/issues/2930

This reverts commit dc8de0a54a5e16338567447b56fd661aa898427e.