### PR TITLE
Initialization of `MobileAds` SDK on the `IO` context.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
+### 4.22.3.0.6
+- Initialization of `MobileAds` SDK on the `IO` context.
+
 ### 4.22.3.0.5
 - Fix memory leaks that could occur when fullscreen ads are shown from an `Activity`.
 

--- a/GoogleBiddingAdapter/build.gradle.kts
+++ b/GoogleBiddingAdapter/build.gradle.kts
@@ -34,7 +34,7 @@ android {
         minSdk = 21
         targetSdk = 33
         // If you touch the following line, don't forget to update scripts/get_rc_version.zsh
-        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.22.3.0.5"
+        android.defaultConfig.versionName = System.getenv("VERSION_OVERRIDE") ?: "4.22.3.0.6"
         buildConfigField("String", "CHARTBOOST_MEDIATION_GOOGLE_BIDDING_ADAPTER_VERSION", "\"${android.defaultConfig.versionName}\"")
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/GoogleBiddingAdapter/src/main/java/com/chartboost/mediation/googlebiddingadapter/GoogleBiddingAdapter.kt
+++ b/GoogleBiddingAdapter/src/main/java/com/chartboost/mediation/googlebiddingadapter/GoogleBiddingAdapter.kt
@@ -152,18 +152,16 @@ class GoogleBiddingAdapter : PartnerAdapter {
     override suspend fun setUp(
         context: Context,
         partnerConfiguration: PartnerConfiguration,
-    ): Result<Unit> {
+    ): Result<Unit> = withContext(IO) {
         PartnerLogController.log(SETUP_STARTED)
 
-        withContext(IO) {
-            // Since Chartboost Mediation is the mediator, no need to initialize AdMob's partner SDKs.
-            // https://developers.google.com/android/reference/com/google/android/gms/ads/MobileAds?hl=en#disableMediationAdapterInitialization(android.content.Context)
-            //
-            // There have been known ANRs when calling disableMediationAdapterInitialization() on the main thread.
-            MobileAds.disableMediationAdapterInitialization(context)
-        }
+        // Since Chartboost Mediation is the mediator, no need to initialize AdMob's partner SDKs.
+        // https://developers.google.com/android/reference/com/google/android/gms/ads/MobileAds?hl=en#disableMediationAdapterInitialization(android.content.Context)
+        //
+        // There have been known ANRs when calling disableMediationAdapterInitialization() on the main thread.
+        MobileAds.disableMediationAdapterInitialization(context)
 
-        return suspendCancellableCoroutine { continuation ->
+        return@withContext suspendCancellableCoroutine { continuation ->
             fun resumeOnce(result: Result<Unit>) {
                 if (continuation.isActive) {
                     continuation.resume(result)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The Chartboost Mediation Google bidding adapter mediates Google bidding via the 
 
 In your `build.gradle`, add the following entry:
 ```
-    implementation "com.chartboost:chartboost-mediation-adapter-google-bidding:4.22.3.0.5"
+    implementation "com.chartboost:chartboost-mediation-adapter-google-bidding:4.22.3.0.6"
 ```
 
 ## Contributions


### PR DESCRIPTION
https://chartboost.atlassian.net/browse/HB-8061

Initialization of `MobileAds` SDK on the `IO` context.

Corollary PR for Ad Mob: https://github.com/ChartBoost/chartboost-mediation-android-adapter-admob/pull/75