### PR TITLE
Updated CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,14 @@
 Note the first digit of every adapter version corresponds to the major version of the Chartboost Mediation SDK compatible with that adapter. 
 Adapters are compatible with any Chartboost Mediation SDK version within that major version.
 
-## 5.23.2.0.0
-- This version of the adapter has been certified with Google Mobile Ads SDK 23.2.0.
-- This version of the adapter supports Chartboost Mediation SDK version 5.+.
+All official releases can be found on this repository's [releases page](https://github.com/ChartBoost/chartboost-mediation-android-adapter-google-bidding/releases).
 
 ### 5.23.3.0.0
 - This version of the adapter has been certified with Google Mobile Ads SDK 23.3.0.
+
+### 5.23.2.0.0
+- This version of the adapter has been certified with Google Mobile Ads SDK 23.2.0.
+- This version of the adapter supports Chartboost Mediation SDK version 5.+.
 
 ### 4.23.2.0.0
 - This version of the adapter has been certified with Google Mobile Ads SDK 23.2.0.


### PR DESCRIPTION
Retroactively update the CHANGELOG to include a link to the official releases page on Github and with Mediation 4 releases (if necessary).